### PR TITLE
Support Rails7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rails", "7.1.5"
+gem "rails", "7.2.2"
 
-gem "actionview", "7.1.5"
-gem "activerecord", "7.1.5"
-gem "activesupport", "7.1.5"
+gem "actionview", "7.2.2"
+gem "activerecord", "7.2.2"
+gem "activesupport", "7.2.2"

--- a/activerecord-turntable.gemspec
+++ b/activerecord-turntable.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.2.2"
 
-  spec.add_runtime_dependency "activerecord",  ">= 5.0", "< 7.2"
-  spec.add_runtime_dependency "activesupport", ">= 5.0", "< 7.2"
+  spec.add_runtime_dependency "activerecord",  ">= 5.0", "< 8.0"
+  spec.add_runtime_dependency "activesupport", ">= 5.0", "< 8.0"
   spec.add_runtime_dependency "bsearch",       "~> 1.5"
   spec.add_runtime_dependency "sql_tree",      "= 0.2.0"
 

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -28,6 +28,27 @@ module ActiveRecord::Turntable
 
       # @note override for append current shard name
       # rubocop:disable Style/HashSyntax, Style/MultilineMethodCallBraceLayout
+      module V7_2
+        def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil, async: false, &block)
+          @instrumenter.instrument(
+            "sql.active_record",
+            sql:               sql,
+            name:              name,
+            binds:             binds,
+            type_casted_binds: type_casted_binds,
+            statement_name:    statement_name,
+            async:             async,
+            connection:        self,
+            transaction:       current_transaction.user_transaction.presence,
+            row_count:         0,
+            turntable_shard_name: turntable_shard_name,
+            &block
+          )
+        rescue ActiveRecord::StatementInvalid => ex
+          raise ex.set_query(sql, binds)
+        end
+      end
+
       module V6_0
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
           @instrumenter.instrument(

--- a/lib/active_record/turntable/active_record_ext/connection_handler_extension.rb
+++ b/lib/active_record/turntable/active_record_ext/connection_handler_extension.rb
@@ -6,7 +6,13 @@ module ActiveRecord::Turntable
       end
 
       # @note Override not to establish_connection destroy existing connection pool proxy object
-      if Util.ar61_or_later?
+      if Util.ar72_or_later?
+        def retrieve_connection_pool(owner, role: ActiveRecord::Base.current_role, shard: ActiveRecord::Base.current_shard, strict: false)
+          owner_to_turntable_pool.fetch(owner) do
+            super
+          end
+        end
+      elsif Util.ar61_or_later?
         def retrieve_connection_pool(owner, role: ActiveRecord::Base.current_role, shard: ActiveRecord::Base.current_shard)
           owner_to_turntable_pool.fetch(owner) do
             super

--- a/lib/active_record/turntable/active_record_ext/database_tasks.rb
+++ b/lib/active_record/turntable/active_record_ext/database_tasks.rb
@@ -35,12 +35,20 @@ module ActiveRecord
       def each_current_turntable_cluster_connected(environment)
         old_connection_pool = ActiveRecord::Base.connection_pool
         each_current_turntable_cluster_configuration(environment) do |name, configuration|
-          ActiveRecord::Base.clear_active_connections!
+          if ActiveRecord::Turntable::Util.ar72_or_later?
+            ActiveRecord::Base.connection_handler.clear_active_connections!
+          else
+            ActiveRecord::Base.clear_active_connections!
+          end
           ActiveRecord::Base.establish_connection(configuration)
           ActiveRecord::Migration.current_shard = name
           yield(name, configuration)
         end
-        ActiveRecord::Base.clear_active_connections!
+        if ActiveRecord::Turntable::Util.ar72_or_later?
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        else
+          ActiveRecord::Base.clear_active_connections!
+        end
         if ActiveRecord::Turntable::Util.ar61_or_later?
           ActiveRecord::Base.establish_connection old_connection_pool.db_config
         else

--- a/lib/active_record/turntable/active_record_ext/fixtures.rb
+++ b/lib/active_record/turntable/active_record_ext/fixtures.rb
@@ -75,103 +75,135 @@ module ActiveRecord
   module TestFixtures
     # rubocop:disable Style/ClassVars, Style/RedundantException
     def setup_fixtures(config = ActiveRecord::Base)
-      if pre_loaded_fixtures && !use_transactional_fixtures
-        raise RuntimeError, "pre_loaded_fixtures requires use_transactional_fixtures"
-      end
+      if ActiveRecord::Turntable::Util.ar72_or_later?
+        if pre_loaded_fixtures && !use_transactional_tests
+          raise RuntimeError, "pre_loaded_fixtures requires use_transactional_tests"
+        end
 
-      @fixture_cache = {}
-      @fixture_connections = []
-      @@already_loaded_fixtures ||= {}
-      @connection_subscriber = nil
-      @legacy_saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
-      @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+        @fixture_cache = {}
+        @fixture_cache_key = [self.class.fixture_table_names.dup, self.class.fixture_paths.dup, self.class.fixture_class_names.dup]
+        @fixture_connection_pools = []
+        @@already_loaded_fixtures ||= {}
+        @connection_subscriber = nil
+        @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
 
-      # Load fixtures once and begin transaction.
-      if run_in_transaction?
-        if @@already_loaded_fixtures[self.class]
-          @loaded_fixtures = @@already_loaded_fixtures[self.class]
+        if run_in_transaction?
+          # Load fixtures once and begin transaction.
+          @loaded_fixtures = @@already_loaded_fixtures[@fixture_cache_key]
+          unless @loaded_fixtures
+            @@already_loaded_fixtures.clear
+            @loaded_fixtures = @@already_loaded_fixtures[@fixture_cache_key] = load_fixtures(config)
+          end
+
+          setup_transactional_fixtures
         else
+          # Load fixtures for every test.
+          ActiveRecord::FixtureSet.reset_cache
+          invalidate_already_loaded_fixtures
           @loaded_fixtures = load_fixtures(config)
-          @@already_loaded_fixtures[self.class] = @loaded_fixtures
         end
 
-        # Begin transactions for connections already established
-        ActiveRecord::Base.force_connect_all_shards!
-        @fixture_connections = enlist_fixture_connections
-        @fixture_connections.each do |connection|
-          connection.begin_transaction joinable: false
-          if ActiveRecord::Turntable::Util.ar51_or_later?
-            connection.pool.lock_thread = true
-          end
-        end
-
-        if ActiveRecord::Turntable::Util.ar71_or_later?
-          @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
-            connection_name = payload[:connection_name] if payload.key?(:connection_name)
-            shard = payload[:shard] if payload.key?(:shard)
-  
-            if connection_name
-              begin
-                connection = ActiveRecord::Base.connection_handler.retrieve_connection(connection_name, shard: shard)
-              rescue ConnectionNotEstablished
-                connection = nil
-              end
-  
-              if connection
-                setup_shared_connection_pool
-  
-                if !@fixture_connections.include?(connection)
-                  connection.begin_transaction joinable: false, _lazy: false
-                  connection.pool.lock_thread = true if lock_threads
-                  @fixture_connections << connection
-                end
-              end
-            end
-          end
-        elsif ActiveRecord::Turntable::Util.ar51_or_later?
-          # When connections are established in the future, begin a transaction too
-          @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
-            spec_name = payload[:spec_name] if payload.key?(:spec_name)
-            if ActiveRecord::Turntable::Util.ar61_or_later?
-              shard = payload[:shard] if payload.key?(:shard)
-              setup_shared_connection_pool if ActiveRecord::Base.legacy_connection_handling
-            end
-
-            if spec_name
-              begin
-                if ActiveRecord::Turntable::Util.ar61_or_later?
-                  connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name, shard: shard)
-                else
-                  connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
-                end
-              rescue ConnectionNotEstablished
-                connection = nil
-              end
-
-              if connection
-                if ActiveRecord::Turntable::Util.ar61_or_later?
-                  setup_shared_connection_pool unless ActiveRecord::Base.legacy_connection_handling
-                end
-
-                if !@fixture_connections.include?(connection)
-                  connection.begin_transaction joinable: false
-                  connection.pool.lock_thread = true
-                  @fixture_connections << connection
-                end
-              end
-            end
-          end
-        end
-
-      # Load fixtures for every test.
+        # Instantiate fixtures for every test if requested.
+        instantiate_fixtures if use_instantiated_fixtures
       else
-        ActiveRecord::FixtureSet.reset_cache
-        @@already_loaded_fixtures[self.class] = nil
-        @loaded_fixtures = load_fixtures(config)
-      end
+        if pre_loaded_fixtures && !use_transactional_fixtures
+          raise RuntimeError, "pre_loaded_fixtures requires use_transactional_fixtures"
+        end
 
-      # Instantiate fixtures for every test if requested.
-      instantiate_fixtures if use_instantiated_fixtures
+        @fixture_cache = {}
+        @fixture_connections = []
+        @@already_loaded_fixtures ||= {}
+        @connection_subscriber = nil
+        @legacy_saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+        @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+
+        # Load fixtures once and begin transaction.
+        if run_in_transaction?
+          if @@already_loaded_fixtures[self.class]
+            @loaded_fixtures = @@already_loaded_fixtures[self.class]
+          else
+            @loaded_fixtures = load_fixtures(config)
+            @@already_loaded_fixtures[self.class] = @loaded_fixtures
+          end
+
+          # Begin transactions for connections already established
+          ActiveRecord::Base.force_connect_all_shards!
+          @fixture_connections = enlist_fixture_connections
+          @fixture_connections.each do |connection|
+            connection.begin_transaction joinable: false
+            if ActiveRecord::Turntable::Util.ar51_or_later?
+              connection.pool.lock_thread = true
+            end
+          end
+
+          if ActiveRecord::Turntable::Util.ar71_or_later?
+            @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
+              connection_name = payload[:connection_name] if payload.key?(:connection_name)
+              shard = payload[:shard] if payload.key?(:shard)
+    
+              if connection_name
+                begin
+                  connection = ActiveRecord::Base.connection_handler.retrieve_connection(connection_name, shard: shard)
+                rescue ConnectionNotEstablished
+                  connection = nil
+                end
+    
+                if connection
+                  setup_shared_connection_pool
+    
+                  if !@fixture_connections.include?(connection)
+                    connection.begin_transaction joinable: false, _lazy: false
+                    connection.pool.lock_thread = true if lock_threads
+                    @fixture_connections << connection
+                  end
+                end
+              end
+            end
+          elsif ActiveRecord::Turntable::Util.ar51_or_later?
+            # When connections are established in the future, begin a transaction too
+            @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
+              spec_name = payload[:spec_name] if payload.key?(:spec_name)
+              if ActiveRecord::Turntable::Util.ar61_or_later?
+                shard = payload[:shard] if payload.key?(:shard)
+                setup_shared_connection_pool if ActiveRecord::Base.legacy_connection_handling
+              end
+
+              if spec_name
+                begin
+                  if ActiveRecord::Turntable::Util.ar61_or_later?
+                    connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name, shard: shard)
+                  else
+                    connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
+                  end
+                rescue ConnectionNotEstablished
+                  connection = nil
+                end
+
+                if connection
+                  if ActiveRecord::Turntable::Util.ar61_or_later?
+                    setup_shared_connection_pool unless ActiveRecord::Base.legacy_connection_handling
+                  end
+
+                  if !@fixture_connections.include?(connection)
+                    connection.begin_transaction joinable: false
+                    connection.pool.lock_thread = true
+                    @fixture_connections << connection
+                  end
+                end
+              end
+            end
+          end
+
+        # Load fixtures for every test.
+        else
+          ActiveRecord::FixtureSet.reset_cache
+          @@already_loaded_fixtures[self.class] = nil
+          @loaded_fixtures = load_fixtures(config)
+        end
+
+        # Instantiate fixtures for every test if requested.
+        instantiate_fixtures if use_instantiated_fixtures
+      end
     end
     # rubocop:enable Style/ClassVars, Style/RedundantException
   end

--- a/lib/active_record/turntable/active_record_ext/query_cache.rb
+++ b/lib/active_record/turntable/active_record_ext/query_cache.rb
@@ -10,6 +10,30 @@ module ActiveRecord::Turntable
       module ClassMethods
         extend Compatibility
 
+        module V7_2
+          def run
+            result = super
+
+            turntable_result = ActiveRecord::Base.turntable_pool_list.reject(&:query_cache_enabled).each do |pool|
+              next if pool.db_config&.query_cache == false
+              pool.enable_query_cache!
+            end
+
+            [result, turntable_result]
+          end
+
+          def complete(pools)
+            original_pools, turntable_pools = pools
+
+            super(original_pools)
+
+            turntable_pools.each do |pool|
+              pool.disable_query_cache!
+              pool.clear_query_cache
+            end
+          end
+        end
+
         module V6_0
         end
 

--- a/lib/active_record/turntable/active_record_ext/transactions.rb
+++ b/lib/active_record/turntable/active_record_ext/transactions.rb
@@ -6,42 +6,58 @@ module ActiveRecord::Turntable
         klass = self.class
         return super unless klass.turntable_enabled?
 
-        status = nil
-        if self.new_record? && self.turntable_shard_key.to_s == klass.primary_key &&
-            self.id.nil? && klass.prefetch_primary_key?
-          self.id = klass.next_sequence_value
-        end
-        connection = self.class.connection
-        if Util.ar61_or_later?
-          ensure_finalize = !connection.transaction_open?
-        end
-
-        connection.shards_transaction([self.turntable_shard]) do
-          if Util.ar61_or_later?
-            add_to_transaction(ensure_finalize || has_transactional_callbacks?)
-            remember_transaction_record_state
-          elsif Util.ar60_or_later?
-            if has_transactional_callbacks?
-              add_to_transaction
-            else
-              sync_with_transaction_state if @transaction_state&.finalized?
-              @transaction_state = self.turntable_shard.connection.transaction_state
-            end
-            remember_transaction_record_state
-          else
-            add_to_transaction
-          end
-
-          begin
-            status = yield
-          rescue ActiveRecord::Rollback
-            clear_transaction_record_state
+        if Util.ar72_or_later?
+          self.class.with_connection do |connection|
             status = nil
+            ensure_finalize = !connection.transaction_open?
+
+            connection.shards_transaction([self.turntable_shard]) do
+              add_to_transaction(ensure_finalize || has_transactional_callbacks?)
+              remember_transaction_record_state
+
+              status = yield
+              raise ActiveRecord::Rollback unless status
+            end
+            status
+          end
+        else
+          status = nil
+          if self.new_record? && self.turntable_shard_key.to_s == klass.primary_key &&
+              self.id.nil? && klass.prefetch_primary_key?
+            self.id = klass.next_sequence_value
+          end
+          connection = self.class.connection
+          if Util.ar61_or_later?
+            ensure_finalize = !connection.transaction_open?
           end
 
-          raise ActiveRecord::Rollback unless status
+          connection.shards_transaction([self.turntable_shard]) do
+            if Util.ar61_or_later?
+              add_to_transaction(ensure_finalize || has_transactional_callbacks?)
+              remember_transaction_record_state
+            elsif Util.ar60_or_later?
+              if has_transactional_callbacks?
+                add_to_transaction
+              else
+                sync_with_transaction_state if @transaction_state&.finalized?
+                @transaction_state = self.turntable_shard.connection.transaction_state
+              end
+              remember_transaction_record_state
+            else
+              add_to_transaction
+            end
+
+            begin
+              status = yield
+            rescue ActiveRecord::Rollback
+              clear_transaction_record_state
+              status = nil
+            end
+
+            raise ActiveRecord::Rollback unless status
+          end
+          status
         end
-        status
       ensure
         if !Util.ar60_or_later? && @transaction_state && @transaction_state.committed?
           clear_transaction_record_state

--- a/lib/active_record/turntable/cluster_helper_methods.rb
+++ b/lib/active_record/turntable/cluster_helper_methods.rb
@@ -30,7 +30,11 @@ module ActiveRecord::Turntable
       end
 
       def force_connect_all_shards!
-        turntable_pool_list.each(&:connection)
+        if Util.ar72_or_later?
+          turntable_pool_list.each(&:lease_connection)
+        else
+          turntable_pool_list.each(&:connection)
+        end
       end
 
       def spec_for(config)

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -101,6 +101,9 @@ module ActiveRecord::Turntable::Migration
 
       ActiveRecord::Tasks::DatabaseTasks.each_current_turntable_cluster_connected(current_environment) do |name, configuration|
         puts "[turntable] *** Migrating database: #{configuration['database']}(Shard: #{name})"
+        if ActiveRecord::Turntable::Util.ar72_or_later?
+          schema_migration.instance_variable_get(:@pool).automatic_reconnect ||= true
+        end
         super(target_version)
       end
 
@@ -112,6 +115,9 @@ module ActiveRecord::Turntable::Migration
 
       ActiveRecord::Tasks::DatabaseTasks.each_current_turntable_cluster_connected(current_environment) do |name, configuration|
         puts "[turntable] *** Migrating database: #{configuration['database']}(Shard: #{name})"
+        if ActiveRecord::Turntable::Util.ar72_or_later?
+          schema_migration.instance_variable_get(:@pool).automatic_reconnect ||= true
+        end
         super(target_version)
       end
 
@@ -123,6 +129,9 @@ module ActiveRecord::Turntable::Migration
 
       ActiveRecord::Tasks::DatabaseTasks.each_current_turntable_cluster_connected(current_environment) do |name, configuration|
         puts "[turntable] *** Migrating database: #{configuration['database']}(Shard: #{name})"
+        if ActiveRecord::Turntable::Util.ar72_or_later?
+          schema_migration.instance_variable_get(:@pool).automatic_reconnect ||= true
+        end
         super(target_version)
       end
 

--- a/lib/active_record/turntable/pool_proxy.rb
+++ b/lib/active_record/turntable/pool_proxy.rb
@@ -7,11 +7,21 @@ module ActiveRecord::Turntable
     attr_reader :proxy
     alias_method :connection, :proxy
 
-    def with_connection
-      yield proxy
+    if Util.ar72_or_later?
+      def with_connection(prevent_permanent_checkout: false)
+        yield proxy
+      end
+    else
+      def with_connection()
+        yield proxy
+      end
     end
 
-    if Util.ar71_or_later?
+    if Util.ar72_or_later?
+      delegate :connected?, :checkout_timeout, :automatic_reconnect, :automatic_reconnect=, :checkout_timeout=,
+      :connections, :size, :reaper, :schema_cache, :schema_cache=, :pool_config, :connection_klass, :discarded?,
+      :connection_class, :async_executor, :shard, :role, :schedule_query, :schema_reflection, :schema_reflection=, :server_version, to: :proxy
+    elsif Util.ar71_or_later?
       delegate :connected?, :checkout_timeout, :automatic_reconnect, :automatic_reconnect=, :checkout_timeout, :checkout_timeout=,
       :connections, :size, :reaper, :schema_cache, :schema_cache=, :pool_config, :connection_klass, :discarded?,
       :connection_class, :async_executor, :shard, :role, :schedule_query, :schema_reflection, :schema_reflection=, to: :proxy
@@ -44,6 +54,25 @@ module ActiveRecord::Turntable
       connection_pools_list.any?(&:active_connection?)
     end
 
+    if Util.ar72_or_later?
+      def lease_connection
+        proxy
+      end
+
+      def disable_query_cache(dirties: true, &block)
+        connection_pools_list.each do |pool|
+          pool.lease_connection.disable_query_cache!
+        end
+        yield
+      end
+
+      def clear_query_cache
+        connection_pools_list.each do |pool|
+          pool.lease_connection.clear_query_cache
+        end
+      end
+    end
+
     %w[
       clear_active_connections!
       clear_all_connections!
@@ -55,6 +84,7 @@ module ActiveRecord::Turntable
       reap
       release_connection
       verify_active_connections!
+      permanent_lease?
     ].each do |name|
       define_method(name.to_sym) do
         connection_pools_list.each { |cp| cp.public_send(name.to_sym) }

--- a/lib/active_record/turntable/shard.rb
+++ b/lib/active_record/turntable/shard.rb
@@ -21,8 +21,14 @@ module ActiveRecord::Turntable
       if use_slave?
         current_slave_shard.connection
       else
-        connection_pool.connection.tap do |conn|
-          conn.turntable_shard_name ||= name
+        if Util.ar72_or_later?
+          connection_pool.lease_connection.tap do |conn|
+            conn.turntable_shard_name ||= name
+          end
+        else
+          connection_pool.connection.tap do |conn|
+            conn.turntable_shard_name ||= name
+          end
         end
       end
     end

--- a/lib/active_record/turntable/sql_tree_patch.rb
+++ b/lib/active_record/turntable/sql_tree_patch.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/kernel/reporting"
 module SQLTree
   class << self
     attr_accessor :identifier_quote_field_char
+    alias_method :original_bracket, :[]
   end
   self.identifier_quote_field_char = "`"
 
@@ -35,6 +36,9 @@ class SQLTree::Token
 end
 
 class SQLTree::Tokenizer
+  alias_method :original_tokenize_quoted_string, :tokenize_quoted_string
+  alias_method :original_tokenize_possible_escaped_string, :tokenize_possible_escaped_string
+
   def tokenize_quoted_string(&block) # :yields: SQLTree::Token::String
     string = ""
     until next_char.nil? || current_char == "'"
@@ -91,6 +95,13 @@ module SQLTree::Node
   end
 
   class SelectQuery < Base
+    class << self
+      alias_method :original_parse, :parse
+      alias_method :original_parse_limit_clause, :parse_limit_clause
+    end
+
+    alias_method :original_to_sql, :to_sql
+
     child :offset
 
     def to_sql(options = {})
@@ -157,6 +168,13 @@ module SQLTree::Node
   end
 
   class TableReference < Base
+    class << self
+      alias_method :original_parse, :parse
+    end
+
+    alias_method :original_initialize, :initialize
+    alias_method :original_to_sql, :to_sql
+
     leaf :index_hint
 
     def initialize(table, table_alias = nil, index_hint = nil)
@@ -231,6 +249,10 @@ module SQLTree::Node
 
   class Expression < Base
     class BinaryOperator < SQLTree::Node::Expression
+      class << self
+        alias_method :original_parse_rhs, :parse_rhs
+      end
+
       TOKEN_PRECEDENCE[2] << SQLTree::Token::BETWEEN
       silence_warnings do
         TOKENS = TOKEN_PRECEDENCE.flatten
@@ -263,12 +285,20 @@ module SQLTree::Node
     end
 
     class Field < Variable
+      alias_method :original_to_sql, :to_sql
+
       def to_sql(options = {})
         @table.nil? ? quote_field_name(@name) : quote_field_name(@table) + "." + quote_field_name(@name)
       end
     end
 
     class Value
+      class << self
+        alias_method :original_parse, :parse
+      end
+
+      alias_method :original_to_sql, :to_sql
+
       leaf :escape
 
       def to_sql(options = {})
@@ -301,6 +331,10 @@ module SQLTree::Node
     end
 
     class EscapedValue < Value
+      class << self
+        alias_method :original_parse_atomic, :parse_atomic
+      end
+
       def initialize(value, escape = nil)
         @value = value
         @escape = escape
@@ -361,6 +395,12 @@ module SQLTree::Node
   end
 
   class InsertQuery < Base
+    class << self
+      alias_method :original_parse_value_list, :parse_value_list
+    end
+
+    alias_method :original_to_sql, :to_sql
+
     def to_sql(options = {})
       sql = "INSERT INTO #{table.to_sql(options)} "
       sql << "(" + fields.map { |f| f.to_sql(options) }.join(", ") + ") " if fields

--- a/lib/active_record/turntable/util.rb
+++ b/lib/active_record/turntable/util.rb
@@ -51,6 +51,10 @@ module ActiveRecord::Turntable
       ar_version_equals_or_later?("7.1")
     end
 
+    def ar72_or_later?
+      ar_version_equals_or_later?("7.2")
+    end
+
     module_function :ar_version_equals_or_later?,
                     :ar_version_earlier_than?,
                     :ar_version,
@@ -62,6 +66,7 @@ module ActiveRecord::Turntable
                     :ar60_or_later?,
                     :ar61_or_later?,
                     :ar70_or_later?,
-                    :ar71_or_later?
+                    :ar71_or_later?,
+                    :ar72_or_later?
   end
 end

--- a/spec/active_record/turntable/active_record_ext/query_cache_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/query_cache_spec.rb
@@ -5,6 +5,13 @@ describe ActiveRecord::Turntable::ActiveRecordExt::QueryCache do
   def middleware(&app)
     executor = Class.new(ActiveSupport::Executor)
     ActiveRecord::QueryCache.install_executor_hooks executor
+    
+    # Rails7.2からConnectionPool内に独自のExecutorHooksが作成されている
+    # https://github.com/rails/rails/pull/53118
+    if ActiveRecord::Turntable::Util.ar72_or_later?
+      ActiveRecord::ConnectionAdapters::ConnectionPool.install_executor_hooks executor
+    end
+
     lambda do |env|
       if ActiveRecord::Turntable::Util.ar60_or_later? && !ActiveRecord::Turntable::Util.ar71_or_later?
         original_handlers = ActiveRecord::Base.connection_handlers

--- a/spec/active_record/turntable/active_record_ext/schema_dumper_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/schema_dumper_spec.rb
@@ -3,7 +3,11 @@ require "spec_helper"
 describe ActiveRecord::Turntable::ActiveRecordExt::SchemaDumper do
   def dump_schema
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    if ActiveRecord::Turntable::Util.ar72_or_later?
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+    else
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    end
     stream.string
   end
 

--- a/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
@@ -16,7 +16,11 @@ describe ActiveRecord::TestFixtures do
 
   describe "#setup_fixtures" do
     after do
-      test_fixture.teardown_fixtures
+      if ActiveRecord::Turntable::Util.ar72_or_later?
+        test_fixture.after_teardown
+      else
+        test_fixture.teardown_fixtures
+      end
     end
 
     subject { test_fixture.setup_fixtures }

--- a/spec/active_record/turntable/connection_proxy_spec.rb
+++ b/spec/active_record/turntable/connection_proxy_spec.rb
@@ -4,7 +4,11 @@ describe ActiveRecord::Turntable::ConnectionProxy do
   context "When initialized" do
     subject { ActiveRecord::Turntable::ConnectionProxy.new(User, cluster) }
     let(:cluster) { ActiveRecord::Base.turntable_configuration.cluster(:user_cluster) }
-    its(:default_connection) { is_expected.to eql(ActiveRecord::Base.connection) }
+    if ActiveRecord::Turntable::Util.ar72_or_later?
+      its(:default_connection) { is_expected.to eql(ActiveRecord::Base.lease_connection) }
+    else
+      its(:default_connection) { is_expected.to eql(ActiveRecord::Base.connection) }
+    end
   end
 
   context "User insert with id" do
@@ -201,24 +205,48 @@ describe ActiveRecord::Turntable::ConnectionProxy do
         expect(result).to all(be true)
       end
 
-      it "each shard has one cache entry within the block" do
-        result = connection_proxy.cache {
-          User.all.to_a
-          klass.turntable_cluster.shards.map do |shard|
+      # QueryCache が Hash じゃなく ActiveRecord::ConnectionAdapters::QueryCache::Store になった
+      # https://github.com/rails/rails/pull/50938
+      if ActiveRecord::Turntable::Util.ar72_or_later?
+        it "each shard has one cache entry within the block" do
+          result = connection_proxy.cache {
+            User.all.to_a
+            klass.turntable_cluster.shards.map do |shard|
+              shard.connection.query_cache.empty?
+            end
+          }
+          expect(result).to all(be false)
+        end
+
+        it "query cache deleted all shard outside of the block" do
+          connection_proxy.cache {
+            User.all.to_a
+          }
+          result = klass.turntable_cluster.shards.map do |shard|
+            shard.connection.query_cache.empty?
+          end
+          expect(result).to all(be true)
+        end
+      else
+        it "each shard has one cache entry within the block" do
+          result = connection_proxy.cache {
+            User.all.to_a
+            klass.turntable_cluster.shards.map do |shard|
+              shard.connection.query_cache.dup
+            end
+          }
+          expect(result).to all(have(1).item)
+        end
+
+        it "query cache deleted all shard outside of the block" do
+          connection_proxy.cache {
+            User.all.to_a
+          }
+          result = klass.turntable_cluster.shards.map do |shard|
             shard.connection.query_cache.dup
           end
-        }
-        expect(result).to all(have(1).item)
-      end
-
-      it "query cache deleted all shard outside of the block" do
-        connection_proxy.cache {
-          User.all.to_a
-        }
-        result = klass.turntable_cluster.shards.map do |shard|
-          shard.connection.query_cache.dup
+          expect(result).to all(be_empty)
         end
-        expect(result).to all(be_empty)
       end
     end
 

--- a/spec/active_record/turntable/pool_proxy_spec.rb
+++ b/spec/active_record/turntable/pool_proxy_spec.rb
@@ -4,7 +4,9 @@ describe ActiveRecord::Turntable::PoolProxy do
   context "When initialized" do
     subject { ActiveRecord::Turntable::PoolProxy.new(nil) }
 
-    UNSUPPORTED_PROXY_METHODS = %i[checkout checkin stat lock_thread= remove num_waiting_in_queue].freeze
+    UNSUPPORTED_PROXY_METHODS = %i[checkout checkin stat lock_thread= remove num_waiting_in_queue
+                                   migration_context permanent_lease? migrations_paths pin_connection!
+                                   unpin_connection! schema_migration internal_metadata active_connection].freeze
 
     context "Comparing original connection pool" do
       (ActiveRecord::ConnectionAdapters::ConnectionPool.instance_methods(false) - UNSUPPORTED_PROXY_METHODS).each do |original_method|

--- a/spec/models/user_profile.rb
+++ b/spec/models/user_profile.rb
@@ -3,5 +3,6 @@ class UserProfile < ActiveRecord::Base
   turntable :user_cluster, :user_id
   sequencer :user_seq
   belongs_to :user
-  serialize :data, JSON
+  # https://github.com/rails/rails/pull/47463
+  serialize :data, coder: JSON
 end


### PR DESCRIPTION
# 目的
activerecord-turntable Rails 7.2で動くように修正。
earth_models, pangaea ではGemfileでこのブランチを見るように設定します。

# 修正方針
* Rails7.2のactiverecordまわりのソースコードをみて、変更箇所を取り込んでいく
* rspecを回してみてエラーになった箇所を修正
* earth_models, pangaeaで動作確認しながらエラーになった箇所を修正

# テスト
- [x] Rails7.2でrspecがオールグリーン

<details>
<summary>rspec結果</summary>

```
$ bundle exec rspec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}
/Users/haraki_aa_masaya/Projects/activerecord-turntable/lib/active_record/turntable/configuration/dsl.rb:63: warning: method redefined; discarding old range

ActiveRecord::FinderMethods
  .find
    pass an ID that exists
      is expected to eq #<User id: 10, nickname: nil, thumbnail_url: nil, blob: nil, joined_at: nil, deleted_at: nil, created_at: "2025-09-01 01:43:40.995763000 +0000", updated_at: "2025-09-01 01:43:40.995763000 +0000">
    pass an ID that doesn't exist
      is expected to raise ActiveRecord::RecordNotFound

ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt
  With sequencer enabled model
    is expected not to raise Exception
    creates one record on shard_1
    creates one record on shard_2

ActiveRecord::Turntable::ActiveRecordExt::AssociationPreloader
  When preloads has_many association
    When associated objects has the same shard key
      is expected not to raise Exception
      its association should be loaded
      its has_many targets should be assigned all related object
    associated objects has different turntable_key
      when foreign_shard_key option passed
        is expected not to raise Exception
        its association should be loaded
        its has_many targets should be assigned all related object
      when foreign_shard_key option is not passed
        is expected to raise ActiveRecord::Turntable::CannotSpecifyShardError

ActiveRecord::Turntable::ActiveRecordExt::Association
  When a model with has_one relation
    When the has_one associated object doesn't exists
      is expected not to raise Exception
  With has_many association
    associated objects has same turntable_key
      AssociationRelation#to_a
        is expected not to raise Exception
        is expected to contain exactly #<UserItemHistory id: 1, user_id: 10, user_item_id: 1, created_at: "2025-09-01 01:43:42.199605000 +0000", updated_at: "2025-09-01 01:43:42.199605000 +0000">
      AssociationRelation#where
        is expected not to raise Exception
        is expected to include #<UserItemHistory id: 1, user_id: 12, user_item_id: 1, created_at: "2025-09-01 01:43:42.284558000 +0000", updated_at: "2025-09-01 01:43:42.284558000 +0000">
    associated objects has different turntable_key
      when foreign_shard_key option passed
        is expected not to raise Exception
        is expected to contain exactly #<UserEventHistory id: 1, user_id: 14, event_user_id: 14, user_item_id: 1, type: nil, created_at: "2025-09-01 01:43:42.390787000 +0000", updated_at: "2025-09-01 01:43:42.390787000 +0000">
      when foreign_shard_key option is not passed
        is expected to raise ActiveRecord::Turntable::CannotSpecifyShardError

ActiveRecord::Turntable::ActiveRecordExt::CleverLoad
  When a model has has_one relation
    When call clever_load!
      With their associations
        makes association target loaded
      With their targets
        loads target object
  When a model has belongs_to relation
    When call clever_load!
      With their associations
        makes target loaded
      With their targets
        loads target object
  When a model has has_many relation
    sends query only 2 times. (PENDING: not implemented yet)

ActiveRecord::Turntable::ActiveRecordExt::ConnectionHandlerExtension
  connection_pool_list should not include PoolProxy

ActiveRecord::FixtureSet
  .create_fixtures
    is expected to be an instance of Array
    creates item records

ActiveRecord::Turntable::ActiveRecordExt::LockingOptimistic
  optimistic locking
    is expected to change `UserProfile#lock_version` by 1
  Json serialized column is saved
    is expected not to raise Exception

ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber
  #sql
    ignore SCHEMA log
    When payload name is `SQL`
      logs in MAGENTA color
    When payload name is `Model Load`
      logs in CYAN color
    When payload includes `:binds` and `:type_casted_binds`
      logs binds parameters

ActiveRecord::Turntable::ActiveRecordExt::Persistence
  #reload
    is expected to be an instance of UserItem
    is expected to eq #<UserItem id: 1, user_id: 29, item_id: 24191, num: 1, deleted_at: nil, created_at: "2025-09-01 01:43:42.595371000 +0000", updated_at: "2025-09-01 01:43:42.595371000 +0000">
    has blob value
      is expected to eq "SSS"
  When the model is sharded by surrogate key
    When updating
      is expected not to raise Exception
      is expected to query like /WHERE `users`\.`id` = 32[^\s]*$/
      is expected to be saved to #<ActiveRecord::Turntable::Shard:0x00000001148fbeb0 @cluster=#<ActiveRecord::Turntable::Cluster:0x000..., @slaves=[]>], @connection_klass=ActiveRecord::Turntable::Shard::Connections::UserShard1(abstract)>
      is expected to change `User#updated_at`
    When destroying
      is expected not to raise Exception
      is expected to query like /WHERE `users`\.`id` = 36[^\s]*$/
  With a model with callbacks
    on update once
      is expected to have received on_update(*(any args)) 1 time
    on destroy once
      is expected to have received on_destroy(*(any args)) 1 time
  When the model is sharded by other key
    warns when creating without shard_key (PENDING: doesn't need to implemented soon)
    When updating
      is expected not to raise Exception
      is expected to query like /`user_items`\.`user_id` = 39[^\s]*($|\s)/
      changes updated_at when updating
    When destroying
      is expected not to raise Exception
      is expected to query like /`user_items`\.`user_id` = 42[^\s]*($|\s)/
    #reload
      is expected not to raise Exception
      is expected to have queried 1
    #touch
      is expected not to raise Exception
      is expected to have queried 1
    #lock!
      is expected not to raise Exception
      is expected to have queried 1
    #update_columns
      is expected not to raise Exception
      is expected to have queried 1
  When the model is not sharded
    is expected not to raise Exception
    is expected to query like /WHERE `items`\.`id` = 24342[^\s]*$/
    is expected not to raise Exception
    is expected to query like /WHERE `items`\.`id` = 24344[^\s]*$/

ActiveRecord::Turntable::ActiveRecordExt::QueryCache
  returns 200 response
  each connection has one query cache when queries to all shard
  each connection has one query cache when queries to all shards
  target connection has one query cache when queries twice
  Outside of QueryCache middleware
    When disabled
      query cache disabled
    When enabled
      query cache enabled
  After QueryCache middleware calls
    releases all active connections

ActiveRecord::Turntable::ActiveRecordExt::SchemaDumper
  #dump
    is expected to match /create_sequence_for "users", force: :cascade, charset: "[^"]+", comment: "[^"]+"/
    is expected not to match /create_table "users_id_seq"/
    is expected not to match /create_sequence_for "users_id_seq".*?do/

ActiveRecord::Turntable::ActiveRecordExt::Sequencer
  With sequencer enabled model
    sequence_name
      is expected not to be nil
  With sequencer disabled model
    sequence_name
      is expected to be nil

ActiveRecord::TestFixtures
  #setup_fixtures
Test is missing assertions: `test` :
    is expected not to raise Exception

ActiveRecord::Turntable::Algorithm::HashSlotAlgorithm
  #choose
    key: 1, slot: 1, target: "user_shard_1"
      is expected to eq "user_shard_1"
    key: 1, slot: 4095, target: "user_shard_1"
      is expected to eq "user_shard_1"
    key: 1, slot: 4096, target: "user_shard_2"
      is expected to eq "user_shard_2"
    with a value overflowed range of shard_maps
      is expected to raise ActiveRecord::Turntable::CannotSpecifyShardError
  #slot_for_key
    key: 1, slot: 12215
      is expected to eq 12215
    key: 2, slot: 15885
      is expected to eq 15885
    key: 3, slot: 3739
      is expected to eq 3739
    with customized hash_func
      key: 1, slot: 2
        is expected to eq 2
      key: 2, slot: 4
        is expected to eq 4
      key: 3, slot: 6
        is expected to eq 6
  #shard_weights
    is expected to have 4 items
    values
      is expected to all eq 4096

ActiveRecord::Turntable::Algorithm::ModuloAlgorithm
  #choose
    key: 1, target: "user_shard_2"
      name
        is expected to eq "user_shard_2"
    key: 2, target: "user_shard_3"
      name
        is expected to eq "user_shard_3"
    key: 3, target: "user_shard_1"
      name
        is expected to eq "user_shard_1"
    with not a number
/Users/haraki_aa_masaya/Projects/activerecord-turntable/lib/active_record/turntable/algorithm/modulo_algorithm.rb:5: warning: too many arguments for format string
      is expected to raise ActiveRecord::Turntable::CannotSpecifyShardError

ActiveRecord::Turntable::Algorithm::RangeBsearchAlgorithm
  #choose
    key: 1, target: "user_shard_1"
      name
        is expected to eq "user_shard_1"
    key: 19999, target: "user_shard_1"
      name
        is expected to eq "user_shard_1"
    key: 20000, target: "user_shard_2"
      name
        is expected to eq "user_shard_2"
    key: 100000, target: "user_shard_3"
      name
        is expected to eq "user_shard_3"
    with a value overflowed range of shard_maps
      is expected to raise ActiveRecord::Turntable::CannotSpecifyShardError
  #shard_weights
    called with 10 returns { shards[0] => 10 }
    called with 25000 returns { shards[0] => 19999, shards[1] => 5001 }
    called with 65000 returns { shards[0] => 39999, shards[1] => 25001 }

ActiveRecord::Turntable::Base
  When installed to ActiveRecord::Base
    ActiveRecord::Base respond_to 'turntable'
  When enable turntable on STI models
    With a STI parent class
      connection
        is expected not to raise Exception
    With a STI subclass
      connection
        is expected not to raise Exception
  .clear_all_connections!
    closes all connections
    In forked child process
      closes all connections

ActiveRecord::Turntable::ClusterHelperMethods
  .all_cluster_transaction
    all shards should begin transaction
    `requires_new` option should be passed to original transaction method
  .cluster_transaction
    all shards in the cluster should begin transaction
  .weighted_random_shard_with
    When checking `shard_fixed?` from given block
      When users table has no record
        is expected to equal true
      When users table has any records
        is expected to equal true
    When checking current target shard from given block
      users_in_each_shard: [10, 10, 10], probabilities_in_each_shard: [0.333, 0.333, 0.333]
        is expected to contain exactly (be within 0.05 of 0.333), (be within 0.05 of 0.333), and (be within 0.05 of 0.333)
      users_in_each_shard: [1, 8, 1], probabilities_in_each_shard: [0.1, 0.8, 0.1]
        is expected to contain exactly (be within 0.05 of 0.1), (be within 0.05 of 0.8), and (be within 0.05 of 0.1)
      users_in_each_shard: [10, 0, 10], probabilities_in_each_shard: [0.5, 0, 0.5]
        is expected to contain exactly (be within 0.05 of 0.5), (be within 0.05 of 0), and (be within 0.05 of 0.5)

ActiveRecord::Turntable::Cluster
  When initialized
    shards
      is expected to have 3 items
    shard_maps
      is expected to have 5 items
  When initialized mysql sequencer type cluster
    shards
      is expected to have 3 items
    shard_maps
      is expected to have 3 items
    #sequencer
      with valid name
        is expected not to equal nil
      with invalid name
        is expected to equal nil
  #shard_for
    with argument in shard range value
      is expected to be an instance of ActiveRecord::Turntable::Shard
      name
        is expected to eq "user_shard_3"
    with argument out of shard range value
      is expected to raise ActiveRecord::Turntable::CannotSpecifyShardError

ActiveRecord::Turntable::Configuration::Loader::YAML
  its sequencers
    instantiate given sequencer

ActiveRecord::Turntable::ConfigurationMethods
  #turntable_configuration_file
    returns Rails.root/config/turntable.yml default
  #turntable_configuration
    is expected to be an instance of ActiveRecord::Turntable::Configuration

ActiveRecord::Turntable::Configuration
  when initialized
    clusters
      is expected to be empty
    sequencers
      is expected to be empty
  .load
    when yaml file passed
      is expected not to raise Exception
      clusters
        is expected to have 5 items
      sequencers
        is expected to have 2 item
    when turntable ruby dsl file passed
      is expected not to raise Exception
      clusters
        is expected to have 5 items
      sequencers
        is expected to have 1 item

ActiveRecord::Turntable::ConnectionProxy
  When initialized
    default_connection
      is expected to eql #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x00000000011b70 env_name="test" role=:writing>
  User insert with id
    user_id: 1
      is expected not to raise Exception
      is expected to be saved to #<ActiveRecord::Turntable::Shard:0x00000001148fbeb0 @cluster=#<ActiveRecord::Turntable::Cluster:0x000..., @slaves=[]>], @connection_klass=ActiveRecord::Turntable::Shard::Connections::UserShard1(abstract)>
    user_id: 20000
      is expected not to raise Exception
      is expected to be saved to #<ActiveRecord::Turntable::Shard:0x00000001148f8210 @cluster=#<ActiveRecord::Turntable::Cluster:0x000..., @slaves=[]>], @connection_klass=ActiveRecord::Turntable::Shard::Connections::UserShard2(abstract)>
    user_id: 20001
      is expected not to raise Exception
      is expected to be saved to #<ActiveRecord::Turntable::Shard:0x00000001148f8210 @cluster=#<ActiveRecord::Turntable::Cluster:0x000..., @slaves=[]>], @connection_klass=ActiveRecord::Turntable::Shard::Connections::UserShard2(abstract)>
    With a SQL Injection intensional value
      is expected not to raise Exception
      is expected to eq "hogehgoge'00"
    With an escaped strings value
      is expected not to raise Exception
      is expected to eq "hoge@\n@\\@@\\nhoge\\\nhoge\\n"
  When have no users
    User.#count should be zero
    User.all should have no item
  When have 2 Users in different shards
    is expected to eq 2
    User.count is 2
    User.all returns 2 User object
    When updating user in shard1
      is expected not to raise Exception
    When updating user in shard2
      is expected not to raise Exception
  #with_all
    When calling User.count within the block
      is expected to have 3 items
      returns User.count of each shards
    With false argument
      When block raises error
        is expected to raise StandardError
    With false argument
      block raises error
        is expected not to raise Exception
        is expected to have 3 items
        is expected to all be an instance of StandardError
  When calling exists? with shard_key
    is expected to be truthy
  When calling exists? with non-existed shard_key
    is expected to be falsey
  When calling exists? with non shard_key
    is expected to be truthy
  When calling exists? with non-existed non shard_key
    is expected to be falsey
  #data_source_exists?
    is expected to be truthy
  QueryCache functions
    #cache
      query cache enabled all connections within the block
      each shard has one cache entry within the block
      query cache deleted all shard outside of the block
    #uncached
      query cache disabled all connections within the block
      each shard has no cache entry within the block
  #with_master
    turntable_shard_name
      is expected to eq "user_shard_1"
  #with_slave
    turntable_shard_name
      is expected to eq "user_shard_1_1"
    inside transaction block
      turntable_shard_name
        is expected to eq "user_shard_1"
    nested with_slave blocks
      outside of 2nd with_slave block
        turntable_shard_name
          is expected to eq "user_shard_1_1"

ActiveRecord::Turntable::Migration
  .target_shards
    With clusters definitions
      is expected to eq [#<ActiveRecord::Turntable::Shard:0x00000001148fbeb0 @cluster=#<ActiveRecord::Turntable::Cluster:0x00... @slaves=[]>], @connection_klass=ActiveRecord::Turntable::Shard::Connections::UserShard3(abstract)>]
    With shards definitions
      is expected to eq [:user_shard_01]

ActiveRecord::Turntable::Mixer
  #divide_insert_values
    with a single insert sql expression
      is expected to be an instance of Hash
      is expected to have key 1
      is expected to have 1 item
    with a bulk insert sql expression
      is expected to be an instance of Hash
      is expected to have key 3
      is expected to all have 1 item
  #build_insert_fader
    with boolean `TRUE` column value
      is expected not to raise Exception
      errors
        is expected to be empty
      published
        is expected to eq true
  #find_shard_keys
    with an update sql expression includes an equals shard_key condition
      is expected to be an instance of Array
      is expected to eq [1]
    with a delete sql expression includes an equals shard_key condition
      is expected to be an instance of Array
      is expected to eq [1]
    with a select sql expression
      includes a single equals condition
        is expected to be an instance of Array
        is expected to eq [1]
      includes duplicated equals conditions
        is expected to be an instance of Array
        is expected to eq [1]
      includes `IN` shard_key condition
        is expected to be an instance of Array
        is expected to eq [1, 2, 3, 4, 5]
      couldn't determine shard_key by their conditions
        is expected to be an instance of Array
        is expected to eq []
      includes shard_key conditions without table prefix
        is expected to be an instance of Array
        is expected to eq []

ActiveRecord::Turntable::PoolProxy
  When initialized
    Comparing original connection pool
      is expected to be respond to :schedule_query
      is expected to be respond to :db_config
      is expected to be respond to :flush
      is expected to be respond to :schema_cache
      is expected to be respond to :release_connection
      is expected to be respond to :connection_class
      is expected to be respond to :checkout_timeout=
      is expected to be respond to :inspect
      is expected to be respond to :connected?
      is expected to be respond to :checkout_timeout
      is expected to be respond to :size
      is expected to be respond to :automatic_reconnect
      is expected to be respond to :schema_reflection
      is expected to be respond to :automatic_reconnect=
      is expected to be respond to :schema_reflection=
      is expected to be respond to :connection
      is expected to be respond to :lease_connection
      is expected to be respond to :discard!
      is expected to be respond to :shard
      is expected to be respond to :active_connection?
      is expected to be respond to :clear_reloadable_connections!
      is expected to be respond to :async_executor
      is expected to be respond to :disconnect!
      is expected to be respond to :reaper
      is expected to be respond to :flush!
      is expected to be respond to :role
      is expected to be respond to :pool_config
      is expected to be respond to :server_version
      is expected to be respond to :disconnect
      is expected to be respond to :with_connection
      is expected to be respond to :discarded?
      is expected to be respond to :clear_reloadable_connections
      is expected to be respond to :connections
      is expected to be respond to :reap

ActiveRecord::Turntable::Sequencer::Api
  #next_sequence_value
    is expected to be a kind of Integer
    is expected to eq 1024
  #current_sequence_value
    is expected to be a kind of Integer
    is expected to eq 1024

ActiveRecord::Turntable::Sequencer::Barrage
  #next_sequence_value
    is expected to be a kind of Integer
  #current_sequence_value
    is expected to be a kind of Integer

ActiveRecord::Turntable::Sequencer::Katsubushi
  #next_sequence_value
    with stub
      is expected to eq 5956206959005697
  #current_sequence_value
    with stub
      is expected to eq 5956206959005697

ActiveRecord::Turntable::Sequencer::Mysql
  #next_sequence_value
    is expected to be a kind of Integer
  #current_sequence_value
    is expected to be a kind of Integer

ActiveRecord::Turntable::Shard
  When initialized
    name
      is expected to eq "user_shard_1"
    connection
      is expected to be an instance of ActiveRecord::ConnectionAdapters::Mysql2Adapter
    connection_pool
      is expected to be an instance of ActiveRecord::ConnectionAdapters::ConnectionPool
  #connection
    turntable_shard_name
      is expected to eq "user_shard_1"

SQLTree
  Insert query with binary string
    is expected not to raise Exception
    to_sql
      is expected to include "x'deadbeef"
  Select query with index hint
    FORCE INDEX
      is expected not to raise Exception
      to_sql
        is expected to include "FORCE INDEX (`foo`)"
    IGNORE INDEX
      is expected not to raise Exception
      to_sql
        is expected to include "IGNORE INDEX (`foo`)"
    USE INDEX
      is expected not to raise Exception
      to_sql
        is expected to include "USE INDEX (`foo`)"
  Select query without index hint
    is expected not to raise Exception
  Select query with inspect
    is expected not to raise Exception
  Delete query
    is expected not to raise Exception

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) ActiveRecord::Turntable::ActiveRecordExt::CleverLoad When a model has has_many relation sends query only 2 times.
     # not implemented yet
     # ./spec/active_record/turntable/active_record_ext/clever_load_spec.rb:54

  2) ActiveRecord::Turntable::ActiveRecordExt::Persistence When the model is sharded by other key warns when creating without shard_key
     # doesn't need to implemented soon
     # ./spec/active_record/turntable/active_record_ext/persistence_spec.rb:99


Deprecation Warnings:

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise Exception` not `expect(value).to raise Exception`


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 3.57 seconds (files took 3.09 seconds to load)
255 examples, 0 failures, 2 pending

[Coveralls] Outside the CI environment, not sending data.
```
</details>

- [x] earth_modelsでCIからrspecをまわして、turntable周りのエラーがでない
- [x] pangaeaでCIからrspecをまわして、turntable周りのエラーがでない
- [x] pangaeaで動作確認
  * [x] ユーザー新規登録できること
  * [x] ユーザープロフィール変更ができること
  * [x] turntable のメソッドが使えること（`with_all`とか`user_cluster_transaction`）

# マージ
以下のPRをmasterに取り込んで、本番で運用安定したらマージ
- https://github.com/AnD00/activerecord-turntable/pull/5

