### PR TITLE
support ruby3.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,9 @@ namespace :turntable do
 
     task :load_config => :rails_env do
       yaml_file = File.join(File.dirname(__FILE__), "spec/config/database.yml")
-      ActiveRecord::Base.configurations = YAML.load(ERB.new(IO.read(yaml_file)).result, aliases: true)
+      # aliases: keyword was added in Psych 4.0 (Ruby 3.1+). Ruby 3.0 uses Psych 3.3, so omit it.
+      # (This branch targets Ruby 3.0 only; Ruby 3.1+ is handled in feature/support-ruby3.2)
+      ActiveRecord::Base.configurations = YAML.load(ERB.new(IO.read(yaml_file)).result)
     end
 
     desc "create turntable test database"

--- a/lib/active_record/turntable/configuration/loader/yaml.rb
+++ b/lib/active_record/turntable/configuration/loader/yaml.rb
@@ -14,7 +14,9 @@ module ActiveRecord::Turntable
       end
 
       def load(env)
-        yaml = YAML.load(ERB.new(IO.read(path)).result, aliases: true).with_indifferent_access[env]
+        # aliases: keyword was added in Psych 4.0 (Ruby 3.1+). Ruby 3.0 uses Psych 3.x, so omit it.
+        # (This branch targets Ruby 3.0 only; Ruby 3.1+ is handled in feature/support-ruby3.2)
+        yaml = YAML.load(ERB.new(IO.read(path)).result).with_indifferent_access[env]
         load_clusters(yaml[:clusters])
         load_global_settings(yaml)
 

--- a/spec/active_record/turntable/active_record_ext/fixture_set_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/fixture_set_spec.rb
@@ -6,7 +6,9 @@ require "active_record/turntable/active_record_ext/fixtures"
 describe ActiveRecord::FixtureSet do
   let(:fixtures_root) { File.join(File.dirname(__FILE__), "../../../fixtures") }
   let(:fixture_file) { File.join(fixtures_root, "items.yml") }
-  let(:items) { YAML.load(ERB.new(IO.read(fixture_file)).result, aliases: true) }
+  # items.yml has no YAML anchors/aliases; aliases: true is not needed.
+  # Removed for Ruby 3.0 (Psych 3.x) compatibility (aliases: was added in Psych 4.0).
+  let(:items) { YAML.load(ERB.new(IO.read(fixture_file)).result) }
 
   before do
     ActiveRecord::FixtureSet.reset_cache

--- a/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
@@ -12,7 +12,9 @@ describe ActiveRecord::TestFixtures do
   let(:fixture_file) { File.join(fixtures_root, "items.yml") }
   let(:test_fixture_class) { Class.new(ActiveSupport::TestCase) { include ActiveRecord::TestFixtures } }
   let(:test_fixture) { test_fixture_class.new("test") }
-  let(:items) { YAML.load(ERB.new(IO.read(fixture_file)).result, aliases: true) }
+  # items.yml has no YAML anchors/aliases; aliases: true is not needed.
+  # Removed for Ruby 3.0 (Psych 3.x) compatibility (aliases: was added in Psych 4.0).
+  let(:items) { YAML.load(ERB.new(IO.read(fixture_file)).result) }
 
   describe "#setup_fixtures" do
     after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,10 @@ MIGRATIONS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "migrations
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
-ActiveRecord::Base.configurations = YAML.load_file(File.join(File.dirname(__FILE__), "config/database.yml"), aliases: true)
+# aliases: keyword was added in Psych 4.0 (Ruby 3.1+). Ruby 3.0 uses Psych 3.x, so omit it.
+# ERB is processed so MYSQL_HOST env var can override the DB host (e.g. when using Docker).
+db_config_file = File.join(File.dirname(__FILE__), "config/database.yml")
+ActiveRecord::Base.configurations = YAML.load(ERB.new(IO.read(db_config_file)).result)
 ActiveRecord::Base.establish_connection(:test)
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
# マージはしない
## 目的
- admin/developerをruby3.0にバージョンアップするが、対応するturntableのバージョンが存在しないため、ruby3.2ブランチを元にruby3.0で動作するバージョンを作成する

## 修正方針
- YAML.Loadの呼び出しに「aliases: true」を指定しているが、ruby3.0標準のpsych3では不要なパラメータとしてArgumentErrorになるため、当該引数を削除
- 後続のストーリーでadmin/developerもruby3.2以降にバージョンアップさせる方針のため、一次的な対応とし、マージはせず、レビュー後にPRはcloseする予定。

## テスト
- [x] ruby3.0を使用してturntableのローカルspecを実行し、エラー０
- [x] earth_adminのCIからspecを実行し、エラー０ 
- [x] dev環境でearth_adminの機能確認を実施して不具合が発生していない 