### PR TITLE
Support Rails8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rails", "8.0.4"
+gem "rails", "8.1.3"
 
-gem "actionview", "8.0.4"
-gem "activerecord", "8.0.4"
-gem "activesupport", "8.0.4"
+gem "actionview", "8.1.3"
+gem "activerecord", "8.1.3"
+gem "activesupport", "8.1.3"

--- a/activerecord-turntable.gemspec
+++ b/activerecord-turntable.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.2.2"
 
-  spec.add_runtime_dependency "activerecord",  ">= 5.0", "< 8.1"
-  spec.add_runtime_dependency "activesupport", ">= 5.0", "< 8.1"
+  spec.add_runtime_dependency "activerecord",  ">= 5.0", "< 8.2"
+  spec.add_runtime_dependency "activesupport", ">= 5.0", "< 8.2"
   spec.add_runtime_dependency "bsearch",       "~> 1.5"
   spec.add_runtime_dependency "sql_tree",      "= 0.2.0"
 

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -28,6 +28,28 @@ module ActiveRecord::Turntable
 
       # @note override for append current shard name
       # rubocop:disable Style/HashSyntax, Style/MultilineMethodCallBraceLayout
+      module V8_1
+        def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)
+          instrumenter.instrument(
+            "sql.active_record",
+            sql:               sql,
+            name:              name,
+            binds:             binds,
+            type_casted_binds: type_casted_binds,
+            async:             async,
+            allow_retry:       allow_retry,
+            connection:        self,
+            transaction:       current_transaction.user_transaction.presence,
+            affected_rows:     0,
+            row_count:         0,
+            turntable_shard_name: turntable_shard_name,
+            &block
+          )
+        rescue ActiveRecord::StatementInvalid => ex
+          raise ex.set_query(sql, binds)
+        end
+      end
+
       module V8_0
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, &block)
           instrumenter.instrument(

--- a/lib/active_record/turntable/pool_proxy.rb
+++ b/lib/active_record/turntable/pool_proxy.rb
@@ -17,7 +17,15 @@ module ActiveRecord::Turntable
       end
     end
 
-    if Util.ar72_or_later?
+    if Util.ar81_or_later?
+      delegate :connected?, :checkout_timeout, :automatic_reconnect, :automatic_reconnect=, :checkout_timeout=,
+      :connections, :size, :max_connections, :min_connections, :max_age, :keepalive,
+      :reaper, :schema_cache, :schema_cache=, :pool_config, :discarded?,
+      :async_executor, :shard, :role, :schedule_query, :schema_reflection, :schema_reflection=, :server_version,
+      :activated?, :maintainable?, :num_available_in_queue, :reaper_lock,
+      :pool_transaction_isolation_level, :pool_transaction_isolation_level=,
+      :with_pool_transaction_isolation_level, to: :proxy
+    elsif Util.ar72_or_later?
       delegate :connected?, :checkout_timeout, :automatic_reconnect, :automatic_reconnect=, :checkout_timeout=,
       :connections, :size, :reaper, :schema_cache, :schema_cache=, :pool_config, :connection_klass, :discarded?,
       :connection_class, :async_executor, :shard, :role, :schedule_query, :schema_reflection, :schema_reflection=, :server_version, to: :proxy
@@ -75,6 +83,20 @@ module ActiveRecord::Turntable
       def clear_query_cache
         connection_pools_list.each do |pool|
           pool.lease_connection.clear_query_cache
+        end
+      end
+    end
+
+    if Util.ar81_or_later?
+      %w[activate recycle! prepopulate preconnect].each do |name|
+        define_method(name.to_sym) do
+          connection_pools_list.each { |cp| cp.public_send(name.to_sym) }
+        end
+      end
+
+      %w[retire_old_connections keep_alive].each do |name|
+        define_method(name.to_sym) do |*args|
+          connection_pools_list.each { |cp| cp.public_send(name.to_sym, *args) }
         end
       end
     end

--- a/lib/active_record/turntable/util.rb
+++ b/lib/active_record/turntable/util.rb
@@ -59,6 +59,10 @@ module ActiveRecord::Turntable
       ar_version_equals_or_later?("8.0")
     end
 
+    def ar81_or_later?
+      ar_version_equals_or_later?("8.1")
+    end
+
     module_function :ar_version_equals_or_later?,
                     :ar_version_earlier_than?,
                     :ar_version,
@@ -72,6 +76,7 @@ module ActiveRecord::Turntable
                     :ar70_or_later?,
                     :ar71_or_later?,
                     :ar72_or_later?,
-                    :ar80_or_later?
+                    :ar80_or_later?,
+                    :ar81_or_later?
   end
 end

--- a/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
@@ -16,11 +16,7 @@ describe ActiveRecord::TestFixtures do
 
   describe "#setup_fixtures" do
     after do
-      if ActiveRecord::Turntable::Util.ar72_or_later?
-        test_fixture.after_teardown
-      else
-        test_fixture.teardown_fixtures
-      end
+      test_fixture.send(:teardown_fixtures)
     end
 
     subject { test_fixture.setup_fixtures }


### PR DESCRIPTION
# 目的
activerecord-turntable Rails 8.1で動くように修正。
earth_models, pangaea ではGemfileでこのブランチを見るように設定します。

# 修正方針
* Rails8.1のactiverecordまわりのソースコードをみて、変更箇所を取り込んでいく
* rspecを回してみてエラーになった箇所を修正
* earth_models, pangaeaで動作確認しながらエラーになった箇所を修正

# テスト
- [x] Rails8.1でrspecがオールグリーン
- [x] earth_modelsでCIからrspecをまわして、turntable周りのエラーがでない
- [x] pangaeaでCIからrspecをまわして、turntable周りのエラーがでない
- [x] pangaeaで動作確認
  * [x] ユーザー新規登録できること
  * [x] ユーザープロフィール変更ができること
  * [x] turntable のメソッドが使えること（`with_all`とか`user_cluster_transaction`）